### PR TITLE
Expose the union types in State type

### DIFF
--- a/src/Autoinput.elm
+++ b/src/Autoinput.elm
@@ -1,7 +1,7 @@
 module Autoinput
     exposing
         ( Model
-        , State
+        , State(NoInput, Selected, Entered)
         , Config
         , Msg
         , preselect
@@ -31,7 +31,7 @@ your data does not go out of sync with the menu list -- and in fact you can
 change the list as the user input changes, enabling common cases such as
 remote querying.
 
-Your list of choices are passed in as a `List (id, item)` &mdash; that is, a 
+Your list of choices are passed in as a `List (id, item)` &mdash; that is, a
 tuple of a unique identifier for the item, and the item itself.
 
 There is a basic usage [example][] to look at, and more are planned.
@@ -91,7 +91,8 @@ import Menu as Menu
 
 -- MODEL
 
-{-| 
+
+{-|
 
 The Autoinput model consists of the input state and the menu state.
 (The menu state is simply whether the menu is visible or not; otherwise, its
@@ -119,9 +120,9 @@ type InternalState id
     | Selecting String id
 
 
-{-| 
+{-|
 
-Selection state. Note to get the current state from an Autoinput model, use 
+Selection state. Note to get the current state from an Autoinput model, use
 `state model`.
 
 -}
@@ -130,7 +131,8 @@ type State id
     | Entered String
     | Selected id
 
-{-|  Configuration passed to both `view` and `update`.
+
+{-| Configuration passed to both `view` and `update`.
 -}
 type Config item
     = Config
@@ -219,7 +221,7 @@ toMaybe (Model model) =
 -- UPDATE
 
 
-{-| 
+{-|
 
 Note that the Msg type specifies the type of the item `id`. So for instance
 if the list you pass in to `view` and `update` is `List (Int, String)`, then


### PR DESCRIPTION
Hi, first of all great work with the library, it is super simple to use and serves its purpose 👍 

I tried using the `state` function to extract the current value but wasn't able to pattern match because the union types are not exposed. This is a pretty small change that exports them.